### PR TITLE
Improve isa check for the config_file attr

### DIFF
--- a/lib/App/Dex.pm
+++ b/lib/App/Dex.pm
@@ -9,7 +9,7 @@ $VERSION = eval $VERSION;
 
 has config_file => (
     is      => 'ro',
-    isa     => sub { -e  $_[0] },
+    isa     => sub { die 'Config file not found' unless $_[0] && -e $_[0] },
     lazy    => 1,
     default => sub {
         first { -e $_ } @{shift->config_file_names};


### PR DESCRIPTION
Running `dex` in a directory with no .dex.yaml causes the program to barf up multiple lines of confusing errors.

This patch reduces that to a single meaningful error message.